### PR TITLE
Added compatibility with "golang.org/x/sys/windows"

### DIFF
--- a/winterm/ansi.go
+++ b/winterm/ansi.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 
 	"github.com/Azure/go-ansiterm"
+	windows "golang.org/x/sys/windows"
 )
 
 // Windows keyboard constants
@@ -164,10 +165,13 @@ func GetStdFile(nFile int) (*os.File, uintptr) {
 	var file *os.File
 	switch nFile {
 	case syscall.STD_INPUT_HANDLE:
+	case windows.STD_INPUT_HANDLE:
 		file = os.Stdin
 	case syscall.STD_OUTPUT_HANDLE:
+	case windows.STD_OUTPUT_HANDLE:
 		file = os.Stdout
 	case syscall.STD_ERROR_HANDLE:
+	case windows.STD_ERROR_HANDLE:
 		file = os.Stderr
 	default:
 		panic(fmt.Errorf("Invalid standard handle identifier: %v", nFile))


### PR DESCRIPTION
Many of the consumers of this library use "golang.org/x/sys/windows" since it's better maintained then syscall package.

This has caused breaking changes with several clients this PR fixes these migration issues + maintain compatibility with the consumers of syscall package